### PR TITLE
Fixed emojis in calendar by extracting the emoji and discarding the img tag

### DIFF
--- a/src/month.ts
+++ b/src/month.ts
@@ -717,7 +717,12 @@ function renderMonthDays(
                             .getValue(curDate);
                         let t = monthInfo.threshold[datasetIndex];
                         if (v !== null && v > t) {
-                            textAnnotation += annotations[datasetIndex];
+                            if (annotations[datasetIndex].includes('class="emoji"')) {
+                                // If it's an emoji, extract it from the <img> tag
+                                textAnnotation += annotations[datasetIndex].match(/alt="([^"]*)"/)[1] ?? annotations[datasetIndex];
+                            } else {
+                                textAnnotation += annotations[datasetIndex];
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Fixes #72

I look for the `class="emoji"` instead of `.startsWith('<img')`because i think the issue should be fixed just for emojis. Images would be a side-effect and maybe in future they have some use.