### PR TITLE
Parse booleans from the frontmatter (fixes #79)

### DIFF
--- a/src/collecting.ts
+++ b/src/collecting.ts
@@ -510,6 +510,13 @@ export function collectDataFromFrontmatterKey(
                 renderInfo.textValueMap
             );
             // console.log(retParse);
+            if (retParse.value === null) {
+                // Try parsing as a boolean: true means 1, false means 0.
+                if (deepValue === 'true' || deepValue === 'false') {
+                    retParse.type = ValueType.Number;
+                    retParse.value = deepValue === 'true' ? 1 : 0;
+                }
+            }
             if (retParse.value !== null) {
                 if (retParse.type === ValueType.Time) {
                     query.valueType = ValueType.Time;

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -316,7 +316,7 @@ export function deepValue(obj: any, str: string) {
     }
     if (typeof obj === "string" || Array.isArray(obj)) {
         return obj;
-    } else if (typeof obj === "number") {
+    } else if (typeof obj === "number" || typeof obj === "boolean") {
         return obj.toString();
     }
     return null;


### PR DESCRIPTION
Hi! This allows parsing boolean values from the frontmatter, following the suggestion in #79 that true should mean 1, false or absence should mean 0.

It's just touching the function that parses values from the frontmatter. I've decided to not change `parseFloatFromAny` in general because that might require adapting each call site of this function to identify if it needed additional changes to handle booleans too. Also, I've had to tweak `deepValue` so it returned boolean values: since the function was returning `string | null | any[]`, I kept that convention and the boolean is converted to a string before being returned (many call sites do `if (deepValue)` with the return value, so that might have been dangerous to just use the bool there).

Please take a look and let me know what you think! Thanks!