### PR TITLE
Change streak counts to terminate on falsey values rather than null

### DIFF
--- a/examples/TestSummary.md
+++ b/examples/TestSummary.md
@@ -21,6 +21,13 @@ summary:
     style: "font-size:20px;color:yellow;margin-left: 50px;margin-top:00px;"
 ```
 
+``` tracker
+searchType: frontmatter
+searchTarget: sleptwell
+folder: diary
+summary:
+    template: "I once slept well for {{maxStreak()::i}} days in a row!"
+```
 ## Using Expressions
 
 Please check [expression examples](https://github.com/pyrochlore/obsidian-tracker/blob/master/examples/TestExpression.md) for more examples.

--- a/examples/diary/2021-01-21.md
+++ b/examples/diary/2021-01-21.md
@@ -18,6 +18,7 @@ deepValue:
                     very: 
                         deep: 11.1
 randchar: B
+sleptwell: false
 ---
 
 #weight:67.3kg

--- a/examples/diary/2021-01-22.md
+++ b/examples/diary/2021-01-22.md
@@ -18,6 +18,7 @@ deepValue:
                     very: 
                         deep: 83.3
 randchar: E
+sleptwell: true
 ---
 
 #weight:64.7kg

--- a/examples/diary/2021-01-23.md
+++ b/examples/diary/2021-01-23.md
@@ -18,6 +18,7 @@ deepValue:
                     very: 
                         deep: 28.8
 randchar: A
+sleptwell: true
 ---
 
 #weight:67.3kg

--- a/examples/diary/2021-01-24.md
+++ b/examples/diary/2021-01-24.md
@@ -18,6 +18,7 @@ deepValue:
                     very: 
                         deep: 39.4
 randchar: B
+sleptwell: true
 ---
 
 #weight:64.1kg

--- a/examples/diary/2021-01-25.md
+++ b/examples/diary/2021-01-25.md
@@ -18,6 +18,7 @@ deepValue:
                     very: 
                         deep: 81.4
 randchar: E
+sleptwell: false
 ---
 
 #weight:62.4kg

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,20 +30,20 @@
       }
     },
     "node_modules/@codemirror/state": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.3.1.tgz",
-      "integrity": "sha512-88e4HhMtKJyw6fKprGaN/yZfiaoGYOi2nM45YCUC6R/kex9sxFWBDGatS1vk4lMgnWmdIIB9tk8Gj1LmL8YfvA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.4.0.tgz",
+      "integrity": "sha512-hm8XshYj5Fo30Bb922QX9hXB/bxOAVH+qaqHBzw5TKa72vOeslyGwd4X8M0c1dJ9JqxlaMceOQ8RsL9tC7gU0A==",
       "dev": true,
       "peer": true
     },
     "node_modules/@codemirror/view": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.22.0.tgz",
-      "integrity": "sha512-6zLj4YIoIpfTGKrDMTbeZRpa8ih4EymMCKmddEDcJWrCdp/N1D46B38YEz4creTb4T177AVS9EyXkLeC/HL2jA==",
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.23.0.tgz",
+      "integrity": "sha512-/51px9N4uW8NpuWkyUX+iam5+PM6io2fm+QmRnzwqBy5v/pwGg9T0kILFtYeum8hjuvENtgsGNKluOfqIICmeQ==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@codemirror/state": "^6.1.4",
+        "@codemirror/state": "^6.4.0",
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
       }
@@ -97,9 +97,9 @@
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.20",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
-      "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
+      "version": "0.3.21",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.21.tgz",
+      "integrity": "sha512-SRfKmRe1KvYnxjEMtxEr+J4HIeMX5YBg/qhRHpxEIGjhX1rshcHlnFUE9K0GazhVKWM7B+nARSkV8LuvJdJ5/g==",
       "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -214,12 +214,12 @@
       }
     },
     "node_modules/@rollup/plugin-typescript": {
-      "version": "11.1.5",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-11.1.5.tgz",
-      "integrity": "sha512-rnMHrGBB0IUEv69Q8/JGRD/n4/n6b3nfpufUu26axhUcboUzv/twfZU8fIBbTOphRAe0v8EyxzeDpKXqGHfyDA==",
+      "version": "11.1.6",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-11.1.6.tgz",
+      "integrity": "sha512-R92yOmIACgYdJ7dJ97p4K69I8gg6IEHt8M7dUBxN3W6nrO8uUxX5ixl0yU/N3aZTi8WhPuICvOHXQvF6FaykAA==",
       "dev": true,
       "dependencies": {
-        "@rollup/pluginutils": "^5.0.1",
+        "@rollup/pluginutils": "^5.1.0",
         "resolve": "^1.22.1"
       },
       "engines": {
@@ -240,9 +240,9 @@
       }
     },
     "node_modules/@rollup/pluginutils": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.5.tgz",
-      "integrity": "sha512-6aEYR910NyP73oHiJglti74iRyOwgFU4x3meH/H8OJx6Ry0j6cOVZ5X/wTvub7G7Ao6qaHBEaNsV3GLJkSsF+Q==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
+      "integrity": "sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==",
       "dev": true,
       "dependencies": {
         "@types/estree": "^1.0.0",
@@ -262,9 +262,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.9.3.tgz",
-      "integrity": "sha512-nvh9bB41vXEoKKvlWCGptpGt8EhrEwPQFDCY0VAto+R+qpSbaErPS3OjMZuXR8i/2UVw952Dtlnl2JFxH31Qvg==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.9.5.tgz",
+      "integrity": "sha512-idWaG8xeSRCfRq9KpRysDHJ/rEHBEXcHuJ82XY0yYFIWnLMjZv9vF/7DOq8djQ2n3Lk6+3qfSH8AqlmHlmi1MA==",
       "cpu": [
         "arm"
       ],
@@ -275,9 +275,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.9.3.tgz",
-      "integrity": "sha512-kffYCJ2RhDL1DlshLzYPyJtVeusHlA8Q1j6k6s4AEVKLq/3HfGa2ADDycLsmPo3OW83r4XtOPqRMbcFzFsEIzQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.9.5.tgz",
+      "integrity": "sha512-f14d7uhAMtsCGjAYwZGv6TwuS3IFaM4ZnGMUn3aCBgkcHAYErhV1Ad97WzBvS2o0aaDv4mVz+syiN0ElMyfBPg==",
       "cpu": [
         "arm64"
       ],
@@ -288,9 +288,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.9.3.tgz",
-      "integrity": "sha512-Fo7DR6Q9/+ztTyMBZ79+WJtb8RWZonyCgkBCjV51rW5K/dizBzImTW6HLC0pzmHaAevwM0jW1GtB5LCFE81mSw==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.9.5.tgz",
+      "integrity": "sha512-ndoXeLx455FffL68OIUrVr89Xu1WLzAG4n65R8roDlCoYiQcGGg6MALvs2Ap9zs7AHg8mpHtMpwC8jBBjZrT/w==",
       "cpu": [
         "arm64"
       ],
@@ -301,9 +301,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.9.3.tgz",
-      "integrity": "sha512-5HcxDF9fqHucIlTiw/gmMb3Qv23L8bLCg904I74Q2lpl4j/20z9ogaD3tWkeguRuz+/17cuS321PT3PAuyjQdg==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.9.5.tgz",
+      "integrity": "sha512-UmElV1OY2m/1KEEqTlIjieKfVwRg0Zwg4PLgNf0s3glAHXBN99KLpw5A5lrSYCa1Kp63czTpVll2MAqbZYIHoA==",
       "cpu": [
         "x64"
       ],
@@ -314,9 +314,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.9.3.tgz",
-      "integrity": "sha512-cO6hKV+99D1V7uNJQn1chWaF9EGp7qV2N8sGH99q9Y62bsbN6Il55EwJppEWT+JiqDRg396vWCgwdHwje8itBQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.9.5.tgz",
+      "integrity": "sha512-Q0LcU61v92tQB6ae+udZvOyZ0wfpGojtAKrrpAaIqmJ7+psq4cMIhT/9lfV6UQIpeItnq/2QDROhNLo00lOD1g==",
       "cpu": [
         "arm"
       ],
@@ -327,9 +327,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.9.3.tgz",
-      "integrity": "sha512-xANyq6lVg6KMO8UUs0LjA4q7di3tPpDbzLPgVEU2/F1ngIZ54eli8Zdt3uUUTMXVbgTCafIO+JPeGMhu097i3w==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.9.5.tgz",
+      "integrity": "sha512-dkRscpM+RrR2Ee3eOQmRWFjmV/payHEOrjyq1VZegRUa5OrZJ2MAxBNs05bZuY0YCtpqETDy1Ix4i/hRqX98cA==",
       "cpu": [
         "arm64"
       ],
@@ -340,9 +340,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.9.3.tgz",
-      "integrity": "sha512-TZJUfRTugVFATQToCMD8DNV6jv/KpSwhE1lLq5kXiQbBX3Pqw6dRKtzNkh5wcp0n09reBBq/7CGDERRw9KmE+g==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.9.5.tgz",
+      "integrity": "sha512-QaKFVOzzST2xzY4MAmiDmURagWLFh+zZtttuEnuNn19AiZ0T3fhPyjPPGwLNdiDT82ZE91hnfJsUiDwF9DClIQ==",
       "cpu": [
         "arm64"
       ],
@@ -353,9 +353,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.9.3.tgz",
-      "integrity": "sha512-4/QVaRyaB5tkEAGfjVvWrmWdPF6F2NoaoO5uEP7N0AyeBw7l8SeCWWKAGrbx/00PUdHrJVURJiYikazslSKttQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.9.5.tgz",
+      "integrity": "sha512-HeGqmRJuyVg6/X6MpE2ur7GbymBPS8Np0S/vQFHDmocfORT+Zt76qu+69NUoxXzGqVP1pzaY6QIi0FJWLC3OPA==",
       "cpu": [
         "riscv64"
       ],
@@ -366,9 +366,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.9.3.tgz",
-      "integrity": "sha512-koLC6D3pj1YLZSkTy/jsk3HOadp7q2h6VQl/lPX854twOmmLNekHB6yuS+MkWcKdGGdW1JPuPBv/ZYhr5Yhtdg==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.9.5.tgz",
+      "integrity": "sha512-Dq1bqBdLaZ1Gb/l2e5/+o3B18+8TI9ANlA1SkejZqDgdU/jK/ThYaMPMJpVMMXy2uRHvGKbkz9vheVGdq3cJfA==",
       "cpu": [
         "x64"
       ],
@@ -379,9 +379,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.9.3.tgz",
-      "integrity": "sha512-0OAkQ4HBp+JO2ip2Lgt/ShlrveOMzyhwt2D0KvqH28jFPqfZco28KSq76zymZwmU+F6GRojdxtQMJiNSXKNzeA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.9.5.tgz",
+      "integrity": "sha512-ezyFUOwldYpj7AbkwyW9AJ203peub81CaAIVvckdkyH8EvhEIoKzaMFJj0G4qYJ5sw3BpqhFrsCc30t54HV8vg==",
       "cpu": [
         "x64"
       ],
@@ -392,9 +392,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.9.3.tgz",
-      "integrity": "sha512-z5uvoMvdRWggigOnsb9OOCLERHV0ykRZoRB5O+URPZC9zM3pkoMg5fN4NKu2oHqgkzZtfx9u4njqqlYEzM1v9A==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.9.5.tgz",
+      "integrity": "sha512-aHSsMnUw+0UETB0Hlv7B/ZHOGY5bQdwMKJSzGfDfvyhnpmVxLMGnQPGNE9wgqkLUs3+gbG1Qx02S2LLfJ5GaRQ==",
       "cpu": [
         "arm64"
       ],
@@ -405,9 +405,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.9.3.tgz",
-      "integrity": "sha512-wxomCHjBVKws+O4N1WLnniKCXu7vkLtdq9Fl9CN/EbwEldojvUrkoHE/fBLZzC7IT/x12Ut6d6cRs4dFvqJkMg==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.9.5.tgz",
+      "integrity": "sha512-AiqiLkb9KSf7Lj/o1U3SEP9Zn+5NuVKgFdRIZkvd4N0+bYrTOovVd0+LmYCPQGbocT4kvFyK+LXCDiXPBF3fyA==",
       "cpu": [
         "ia32"
       ],
@@ -418,9 +418,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.9.3.tgz",
-      "integrity": "sha512-1Qf/qk/iEtx0aOi+AQQt5PBoW0mFngsm7bPuxHClC/hWh2hHBktR6ktSfUg5b5rC9v8hTwNmHE7lBWXkgqluUQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.9.5.tgz",
+      "integrity": "sha512-1q+mykKE3Vot1kaFJIDoUFv5TuW+QQVaf2FmTT9krg86pQrGStOSJJ0Zil7CFagyxDuouTepzt5Y5TVzyajOdQ==",
       "cpu": [
         "x64"
       ],
@@ -614,9 +614,9 @@
       "dev": true
     },
     "node_modules/@types/d3-quadtree": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.5.tgz",
-      "integrity": "sha512-Cb1f3jyNBnvMMkf4KBZ7IgAQVWd9yzBwYcrxGqg3aPCUgWELAS+nyeB7r76aqu1e3+CGDjhk4BrWaFBekMwigg==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
       "dev": true
     },
     "node_modules/@types/d3-random": {
@@ -635,9 +635,9 @@
       }
     },
     "node_modules/@types/d3-scale-chromatic": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.0.2.tgz",
-      "integrity": "sha512-kpKNZMDT3OAX6b5ct5nS/mv6LULagnUy4DmS6yyNjclje1qVe7vbjPwY3q1TGz6+Wr2IUkgFatCzqYUl54fHag==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.0.3.tgz",
+      "integrity": "sha512-laXM4+1o5ImZv3RpFAsTRn3TEkzqkytiOY0Dz0sq5cnd1dtNlk6sHLon4OvqaiJb28T0S/TdsBI3Sjsy+keJrw==",
       "dev": true
     },
     "node_modules/@types/d3-selection": {
@@ -647,9 +647,9 @@
       "dev": true
     },
     "node_modules/@types/d3-shape": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.5.tgz",
-      "integrity": "sha512-dfEWpZJ1Pdg8meLlICX1M3WBIpxnaH2eQV2eY43Y5ysRJOTAV9f3/R++lgJKFstfrEOE2zdJ0sv5qwr2Bkic6Q==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.6.tgz",
+      "integrity": "sha512-5KKk5aKGu2I+O6SONMYSNflgiP0WfZIQvVUMan50wHsLG1G94JlxEVnCpQARfTtzytuY0p/9PXXZb3I7giofIA==",
       "dev": true,
       "dependencies": {
         "@types/d3-path": "*"
@@ -730,9 +730,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.10.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.6.tgz",
-      "integrity": "sha512-Vac8H+NlRNNlAmDfGUP7b5h/KA+AtWIzuXy0E6OyP8f1tCLYAtPvKRRDJjAPqhpCb0t6U2j7/xqAuLEebW2kiw==",
+      "version": "20.11.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.5.tgz",
+      "integrity": "sha512-g557vgQjUUfN76MZAN/dt1z3dzcUsimuysco0KeluHgrPdJXkP/XdAURgyO2W9fZWHRtRBiVKzKn8vyOAwlG+w==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -751,18 +751,18 @@
       "dev": true
     },
     "node_modules/@types/tern": {
-      "version": "0.23.7",
-      "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.7.tgz",
-      "integrity": "sha512-0YS9XCZ0LAhlP11HV9SqncUYyz9Ggsgc7Om/AmchKvoeFyj0qPaJmX6rJ93mJVExizWDzUMb49gAtVpI1uHd8Q==",
+      "version": "0.23.9",
+      "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.9.tgz",
+      "integrity": "sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==",
       "dev": true,
       "dependencies": {
         "@types/estree": "*"
       }
     },
     "node_modules/acorn": {
-      "version": "8.11.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
-      "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -1273,9 +1273,9 @@
       }
     },
     "node_modules/fastq": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
-      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.16.0.tgz",
+      "integrity": "sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==",
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
@@ -1644,9 +1644,9 @@
       }
     },
     "node_modules/obsidian": {
-      "version": "1.4.11",
+      "version": "1.5.1",
       "resolved": "https://github.com/obsidianmd/obsidian-api/tarball/master",
-      "integrity": "sha512-erAaIpFoS77/0/Z2EdNXMI5Kd0jTZvS17Cl/753klHvV7IFgdqD7GPUmiACPN52yOc6iHBwuDuPR1sv6Lz6DCA==",
+      "integrity": "sha512-zXhEivZGOKIBmN2ahr+Shh98RMEM9Ih9RsjD2RLEyVqLwu87mTYYVxLGPfWwsLD06zKUltIGqLpNG9+x5tyILA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1765,9 +1765,9 @@
       "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="
     },
     "node_modules/rollup": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.9.3.tgz",
-      "integrity": "sha512-JnchF0ZGFiqGpAPjg3e89j656Ne4tTtCY1VZc1AxtoQcRIxjTu9jyYHBAtkDXE+X681n4un/nX9SU52AroSRzg==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.9.5.tgz",
+      "integrity": "sha512-E4vQW0H/mbNMw2yLSqJyjtkHY9dslf/p0zuT1xehNRqUTBOFMqEjguDvqhXr7N7r/4ttb2jr4T41d3dncmIgbQ==",
       "dev": true,
       "dependencies": {
         "@types/estree": "1.0.5"
@@ -1780,19 +1780,19 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.9.3",
-        "@rollup/rollup-android-arm64": "4.9.3",
-        "@rollup/rollup-darwin-arm64": "4.9.3",
-        "@rollup/rollup-darwin-x64": "4.9.3",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.9.3",
-        "@rollup/rollup-linux-arm64-gnu": "4.9.3",
-        "@rollup/rollup-linux-arm64-musl": "4.9.3",
-        "@rollup/rollup-linux-riscv64-gnu": "4.9.3",
-        "@rollup/rollup-linux-x64-gnu": "4.9.3",
-        "@rollup/rollup-linux-x64-musl": "4.9.3",
-        "@rollup/rollup-win32-arm64-msvc": "4.9.3",
-        "@rollup/rollup-win32-ia32-msvc": "4.9.3",
-        "@rollup/rollup-win32-x64-msvc": "4.9.3",
+        "@rollup/rollup-android-arm-eabi": "4.9.5",
+        "@rollup/rollup-android-arm64": "4.9.5",
+        "@rollup/rollup-darwin-arm64": "4.9.5",
+        "@rollup/rollup-darwin-x64": "4.9.5",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.9.5",
+        "@rollup/rollup-linux-arm64-gnu": "4.9.5",
+        "@rollup/rollup-linux-arm64-musl": "4.9.5",
+        "@rollup/rollup-linux-riscv64-gnu": "4.9.5",
+        "@rollup/rollup-linux-x64-gnu": "4.9.5",
+        "@rollup/rollup-linux-x64-musl": "4.9.5",
+        "@rollup/rollup-win32-arm64-msvc": "4.9.5",
+        "@rollup/rollup-win32-ia32-msvc": "4.9.5",
+        "@rollup/rollup-win32-x64-msvc": "4.9.5",
         "fsevents": "~2.3.2"
       }
     },
@@ -1866,9 +1866,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
-      "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
       "dev": true,
       "dependencies": {
         "randombytes": "^2.1.0"
@@ -1933,9 +1933,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.24.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.24.0.tgz",
-      "integrity": "sha512-ZpGR4Hy3+wBEzVEnHvstMvqpD/nABNelQn/z2r0fjVWGQsN3bpOLzQlqDxmb4CDZnXq5lpjnQ+mHQLAOpfM5iw==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.27.0.tgz",
+      "integrity": "sha512-bi1HRwVRskAjheeYl291n3JC4GgO/Ty4z1nVs5AAsmonJulGxpSektecnNedrwK9C7vpvVtcX3cw00VSLt7U2A==",
       "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",

--- a/src/expr.ts
+++ b/src/expr.ts
@@ -167,7 +167,7 @@ const fnMapDatasetToValue: FnMapDatasetToValue = {
         let streak = 0;
         let maxStreak = 0;
         for (let dataPoint of dataset) {
-            if (dataPoint.value !== null) {
+            if (dataPoint.value) {
                 streak++;
             } else {
                 streak = 0;
@@ -186,7 +186,7 @@ const fnMapDatasetToValue: FnMapDatasetToValue = {
         let maxStreakStart: Moment = null;
         if (dataset) {
             for (let dataPoint of dataset) {
-                if (dataPoint.value !== null) {
+                if (dataPoint.value) {
                     if (streak === 0) {
                         streakStart = dataPoint.date;
                     }
@@ -216,9 +216,9 @@ const fnMapDatasetToValue: FnMapDatasetToValue = {
                 if (ind < arrayDataset.length - 1) {
                     nextPoint = arrayDataset[ind + 1];
                 }
-                if (point.value !== null) {
+                if (point.value) {
                     streak++;
-                    if (nextPoint?.value === null) {
+                    if (!nextPoint?.value) {
                         streakEnd = point.date;
                     }
                 } else {
@@ -239,7 +239,7 @@ const fnMapDatasetToValue: FnMapDatasetToValue = {
         let breaks = 0;
         let maxBreaks = 0;
         for (let dataPoint of dataset) {
-            if (dataPoint.value === null) {
+            if (!dataPoint.value) {
                 breaks++;
             } else {
                 breaks = 0;
@@ -258,7 +258,7 @@ const fnMapDatasetToValue: FnMapDatasetToValue = {
         let maxBreaksStart: Moment = null;
         if (dataset) {
             for (let dataPoint of dataset) {
-                if (dataPoint.value === null) {
+                if (!dataPoint.value) {
                     if (breaks === 0) {
                         breaksStart = dataPoint.date;
                     }
@@ -288,9 +288,9 @@ const fnMapDatasetToValue: FnMapDatasetToValue = {
                 if (ind < arrayDataset.length - 1) {
                     nextPoint = arrayDataset[ind + 1];
                 }
-                if (point.value === null) {
+                if (!point.value) {
                     breaks++;
-                    if (nextPoint?.value !== null) {
+                    if (nextPoint?.value) {
                         breaksEnd = point.date;
                     }
                 } else {
@@ -314,7 +314,7 @@ const fnMapDatasetToValue: FnMapDatasetToValue = {
             let arrayDataset = Array.from(dataset);
             for (let ind = arrayDataset.length - 1; ind >= 0; ind--) {
                 let point = arrayDataset[ind];
-                if (point.value === null) {
+                if (!point.value) {
                     break;
                 } else {
                     currentStreak++;
@@ -334,7 +334,7 @@ const fnMapDatasetToValue: FnMapDatasetToValue = {
                 if (ind < arrayDataset.length - 1) {
                     currentStreakStart = arrayDataset[ind + 1].date;
                 }
-                if (point.value === null) {
+                if (!point.value) {
                     break;
                 } else {
                     currentStreak++;
@@ -355,7 +355,7 @@ const fnMapDatasetToValue: FnMapDatasetToValue = {
             let arrayDataset = Array.from(dataset);
             for (let ind = arrayDataset.length - 1; ind >= 0; ind--) {
                 let point = arrayDataset[ind];
-                if (point.value === null) {
+                if (!point.value) {
                     break;
                 } else {
                     if (currentStreak === 0) {
@@ -378,7 +378,7 @@ const fnMapDatasetToValue: FnMapDatasetToValue = {
             let arrayDataset = Array.from(dataset);
             for (let ind = arrayDataset.length - 1; ind >= 0; ind--) {
                 let point = arrayDataset[ind];
-                if (point.value === null) {
+                if (!point.value) {
                     currentBreaks++;
                 } else {
                     break;
@@ -398,7 +398,7 @@ const fnMapDatasetToValue: FnMapDatasetToValue = {
                 if (ind < arrayDataset.length - 1) {
                     currentBreaksStart = arrayDataset[ind + 1].date;
                 }
-                if (point.value === null) {
+                if (!point.value) {
                     currentBreaks++;
                 } else {
                     break;
@@ -419,7 +419,7 @@ const fnMapDatasetToValue: FnMapDatasetToValue = {
             let arrayDataset = Array.from(dataset);
             for (let ind = arrayDataset.length - 1; ind >= 0; ind--) {
                 let point = arrayDataset[ind];
-                if (point.value === null) {
+                if (!point.value) {
                     if (currentBreaks === 0) {
                         currentBreaksEnd = point.date;
                     }


### PR DESCRIPTION
# Description

Changes some lines in expr.ts to check for any falsey value (or any truthy value) rather than the explicit presence of null. This allows users to define true/false frontmatter tags, with false not counting towards a streak. This is how Obsidian handles checkbox properties, so it fixes issues concerning those too.

Fixes # (issue)
#299 #291
## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] If this is a bug fix, did you add or update a test file to the examples directory that verifies the bug is fixed?
