### PR TITLE
Add percentile function for p-quantile

### DIFF
--- a/docs/Expressions.md
+++ b/docs/Expressions.md
@@ -83,6 +83,7 @@ e.g.
 | currentBreaksEnd(Dataset): Date | End date of current breaks |
 | average(Dataset): number | Average value of the dataset |
 | median(Dataset): number | Median value of the dataset |
+| percentile(Dataset, percentile): number | Percentile-quantile value of the dataset |
 | variance(Dataset): number | Variance value of the dataset |
 
 ### Functions Accept Dataset and Return Dataset

--- a/examples/TestExpression.md
+++ b/examples/TestExpression.md
@@ -336,6 +336,25 @@ summary:
     template: 'Median value: {{median()::i}} <-- should be 25'
 ```
 
+percentage(Dataset): number
+``` tracker
+searchType: dvField
+searchTarget: dataviewTarget
+folder: /diary
+endDate: 2021-01-03
+summary:
+    template: '20-percentile value: {{percentage(dataset(0),0.2)::.1f}} <-- should be 17.2'
+```
+
+``` tracker
+searchType: dvField
+searchTarget: dataviewTarget
+folder: /diary
+endDate: 2021-01-03
+summary:
+    template: '60-percentile value: {{percentage(dataset(0),0.6)::.1f}} <-- should be 29.6'
+```
+
 variance(Dataset): number
 https://mathworld.wolfram.com/SampleVariance.html
 ``` tracker

--- a/src/expr.ts
+++ b/src/expr.ts
@@ -448,6 +448,10 @@ const fnMapDatasetToValue: FnMapDatasetToValue = {
         // return number
         return d3.median(dataset.getValues());
     },
+    percentile: function (dataset, percentage, renderInfo) {
+        // return number
+        return d3.quantile(dataset.getValues(), percentage / 100);
+    },
     variance: function (dataset, renderInfo) {
         // return number
         return d3.variance(dataset.getValues());


### PR DESCRIPTION
# Description

Add [percentile function](https://d3js.org/d3-array/summarize#quantile) for datasets with p-quantile based from an array of numbers. `percentile` value is 0 to 100.
## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [ ] If this is a new feature, did you add files to the examples directory to demonstrate the feature?
- [x] If this is a new feature, did you add documentation to the docs directory for the feature?
