### PR TITLE
Enable Stacked Bar Chart #enhancement

### DIFF
--- a/docs/InputParameters.md
+++ b/docs/InputParameters.md
@@ -37,6 +37,7 @@ These key-value pairs are placed under the root of the code block.
 | `ignoreAttachedValue` | Use `constValue` even if the target has a value attached on (true\|false) | 1~NT | false |
 | `ignoreZeroValue` | Treat zero value as missing (true\|false) | 1~NT | false |
 | `accum` | Accumulatively sum the values over time (true\|false) | 1~NT | false |
+| `stack` | Support stacked charts (true\|false) | 1 | false |
 | `penalty` | Value to use if the search target is missing on the day | 1~NT | |
 | `valueShift` | Amount to shift for each collected value | 1~NT | 0 |
 | `shiftOnlyValueLargerThan` | Do `valueShift` only if the value is larger then the specifed one | 1~NT | null |

--- a/examples/TestBarChart.md
+++ b/examples/TestBarChart.md
@@ -53,4 +53,18 @@ bar:
     barColor: yellow, red, green, blue, orange, white
 ```
 
+
+``` tracker
+searchType: tag
+searchTarget: sinsquare[0], sinsquare[1], sinsquare[2], sinsquare[3], sinsquare[4], sinsquare[5]
+folder: diary
+startDate: 2021-01-01
+endDate: 2021-01-05
+stack: true
+bar:
+    title: Sin Square Wave (Stacked)
+    yAxisLabel: Value
+    yMin: 0
+    barColor: yellow, red, green, blue, orange, black
+```
 Please also check those search targets in markdown files under folder 'diary'.

--- a/src/data.ts
+++ b/src/data.ts
@@ -391,6 +391,25 @@ export class Dataset implements IterableIterator<DataPoint> {
         }
     }
 
+    public shiftByDataset(shiftDataset: Dataset) {
+        // Assume all datasets are of the same length
+        for (let ind = 0; ind < this.values.length; ind++) {
+            let currentValue = this.values[ind];
+            if (shiftDataset.values[ind] !== null && currentValue !== null) {
+                currentValue += shiftDataset.values[ind];
+            } else if (shiftDataset.values[ind] !== null) {
+                currentValue = shiftDataset.values[ind];
+            }
+            this.values[ind] = currentValue;
+            if (currentValue < this.yMin) {
+                this.yMin = currentValue;
+            }
+            if (currentValue > this.yMax) {
+                this.yMax = currentValue;
+            }
+        }
+    }
+
     public getValues() {
         return this.values;
     }
@@ -571,6 +590,7 @@ export class RenderInfo {
     ignoreAttachedValue: boolean[];
     ignoreZeroValue: boolean[];
     accum: boolean[];
+    stack: boolean;
     penalty: number[];
     valueShift: number[];
     shiftOnlyValueLargerThan: number[];
@@ -614,6 +634,7 @@ export class RenderInfo {
         this.ignoreAttachedValue = []; // false
         this.ignoreZeroValue = []; // false
         this.accum = []; // false, accum values start from zero over days
+        this.stack = false;
         this.penalty = []; // null, use this value instead of null value
         this.valueShift = [];
         this.shiftOnlyValueLargerThan = [];

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -1459,6 +1459,12 @@ export function getRenderInfoFromYaml(
     renderInfo.accum = retAccum;
     // console.log(renderInfo.accum);
 
+    // stack
+    if (typeof yaml.stack === "boolean") {
+        renderInfo.stack = yaml.stack;
+    }
+    // console.log(renderInfo.stack);
+
     // penalty
     let retPenalty = getNumberArrayFromInput(
         "penalty",


### PR DESCRIPTION
# Description

Enable stacked bar chart when user set stack to `true`.
Currently only works with all positive or all negative numbers.

![Screenshot 2024-04-27 220239](https://github.com/pyrochlore/obsidian-tracker/assets/1567536/1cb8f097-07b5-48ee-9bfe-d67c07ce25f5)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] If this is a bug fix, did you add or update a test file to the examples directory that verifies the bug is fixed?
- [x] If this is a new feature, did you add files to the examples directory to demonstrate the feature?
- [x] If this is a new feature, did you add documentation to the docs directory for the feature?
