### PR TITLE
Pervent overlapping external labels in pie chart

### DIFF
--- a/examples/TestPieChart.md
+++ b/examples/TestPieChart.md
@@ -115,3 +115,18 @@ pie:
     hideLabelLessThan: 0.03
     showExtLabelOnlyIfNoLabel: true
 ```
+
+When there are multiple external labels, make sure they won't overlap with each other
+``` tracker
+searchType: task.done, task.notdone
+searchTarget: Say I love you, Say I love you
+datasetName: Done, NotDone
+pie:
+    label: '{{0.5/11*100}}%, B {{0.4/11*100}}%, C {{0.1/11*100}}%, D {{8/11*100}}%, E {{9.7/11*100}}%, F {{0.3/28.5*100}}'
+    extLabel:  'A {{0.5/11*100}}%, B {{0.4/11*100}}%, C {{0.1/11*100}}%, D {{8/11*100}}%, E {{9.7/11*100}}, F {{0.3/11*100}}%'
+    data: '0.5, 0.4, 0.1, 8, 9.7, 0.3'
+    dataColor: '#4daf4a,#377eb8,#ff7f00,#984ea3,#e41a1c,#aaaaaa'
+    ratioInnerRadius: 0.4
+    hideLabelLessThan: 0.03
+    showExtLabelOnlyIfNoLabel: true
+```


### PR DESCRIPTION
# Description

Currently when there are multiple small categories in pie chart, the external label would overlap with each other.
![Screenshot 2024-04-28 162205](https://github.com/pyrochlore/obsidian-tracker/assets/1567536/dd32507d-0734-4a51-9bd0-7b79dba548f6)

This change will prevent it from happening but moving down the label up on detecting overlap.
![Screenshot 2024-04-28 162446](https://github.com/pyrochlore/obsidian-tracker/assets/1567536/8f272c76-0e7b-41ce-9b41-f8fb9a94b5b6)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] If this is a bug fix, did you add or update a test file to the examples directory that verifies the bug is fixed?
- [ ] If this is a new feature, did you add files to the examples directory to demonstrate the feature?
- [ ] If this is a new feature, did you add documentation to the docs directory for the feature?
