### PR TITLE
Respect thresholds in scaled months

### DIFF
--- a/examples/TestCalendar.md
+++ b/examples/TestCalendar.md
@@ -46,7 +46,7 @@ month:
 ```
 
 ### Colored by Values
-Use parameter `circleColorByValue`, color the circles based on the values
+Use parameters `circleColorByValue`, `yMin`, and `yMax`, to color the circles based on the values
 ``` tracker
 searchType: tag
 searchTarget: exercise-pushup
@@ -54,13 +54,15 @@ datasetName: PushUp
 folder: diary
 month:
     startWeekOn:
-    threshold: 40
+    threshold: 10
     color: green
     headerMonthColor: orange
     dimNotInMonth: false
     todayRingColor: orange
     selectedRingColor: steelblue
     circleColorByValue: true
+	yMin: 0
+	yMax: 50
     showSelectedValue: true
 ```
 

--- a/examples/TestCalendar.md
+++ b/examples/TestCalendar.md
@@ -61,8 +61,8 @@ month:
     todayRingColor: orange
     selectedRingColor: steelblue
     circleColorByValue: true
-	yMin: 0
-	yMax: 50
+    yMin: 0
+    yMax: 50
     showSelectedValue: true
 ```
 

--- a/examples/diary/2021-01-05.md
+++ b/examples/diary/2021-01-05.md
@@ -22,7 +22,7 @@ randchar: A
 
 #weight:72.5kg
 
-#exercise-pushup:49
+#exercise-pushup:5
 #exercise-plank:57sec
 
 #meditation

--- a/examples/diary/20210105-D.md
+++ b/examples/diary/20210105-D.md
@@ -6,7 +6,7 @@ bloodpressure: 177/119
 
 #weight:70.0kg
 
-#exercise-pushup:35
+#exercise-pushup:5
 #exercise-plank:34sec
 
 #meditation

--- a/examples/diary/D-20210105.md
+++ b/examples/diary/D-20210105.md
@@ -6,7 +6,7 @@ bloodpressure: 177/119
 
 #weight:70.0kg
 
-#exercise-pushup:35
+#exercise-pushup:5
 #exercise-plank:34sec
 
 #meditation

--- a/examples/diary/Jeffrey-20210105-Diary.md
+++ b/examples/diary/Jeffrey-20210105-Diary.md
@@ -6,7 +6,7 @@ bloodpressure: 177/119
 
 #weight:70.0kg
 
-#exercise-pushup:35
+#exercise-pushup:5
 #exercise-plank:34sec
 
 #meditation

--- a/examples/diary/Jeffrey-20210105-Journal.md
+++ b/examples/diary/Jeffrey-20210105-Journal.md
@@ -6,7 +6,7 @@ bloodpressure: 177/119
 
 #weight:70.0kg
 
-#exercise-pushup:35
+#exercise-pushup:5
 #exercise-plank:34sec
 
 #meditation

--- a/examples/diary/Lucas-20210105-Diary.md
+++ b/examples/diary/Lucas-20210105-Diary.md
@@ -6,7 +6,7 @@ bloodpressure: 177/119
 
 #weight:70.0kg
 
-#exercise-pushup:35
+#exercise-pushup:5
 #exercise-plank:34sec
 
 #meditation

--- a/examples/diary/Lucas-20210105-Journal.md
+++ b/examples/diary/Lucas-20210105-Journal.md
@@ -6,7 +6,7 @@ bloodpressure: 177/119
 
 #weight:70.0kg
 
-#exercise-pushup:35
+#exercise-pushup:5
 #exercise-plank:34sec
 
 #meditation

--- a/src/month.ts
+++ b/src/month.ts
@@ -643,26 +643,7 @@ function renderMonthDays(
             console.log(curValue);
         }
 
-        // showCircle
-        let showCircle = false;
-        if (!monthInfo.circleColorByValue) {
-            // shown or not shown
-            if (curValue !== null) {
-                if (curValue > threshold) {
-                    showCircle = true;
-                }
-            }
-        } else {
-            if (!allowScaledValue) {
-                if (curValue !== null) {
-                    if (curValue > threshold) {
-                        showCircle = true;
-                    }
-                }
-            } else {
-                showCircle = true;
-            }
-        }
+        const showCircle = curValue != null && curValue > threshold;
 
         // scaledValue
         let scaledValue = null;


### PR DESCRIPTION
# Description

See https://github.com/pyrochlore/obsidian-tracker/issues/364 for description. Ensures that the `month` graph's `threshold` parameter, even when `circleColorByValue` is also used.

Fixes #364

Note that I just raised that issue myself, and it appears that the behavior I'm removing was added intentionally. So, I'd understand if this PR is rejected (although I would be curious to hear *why* it behaves the way it does).

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] If this is a bug fix, did you add or update a test file to the examples directory that verifies the bug is fixed?
