### PR TITLE
Solution to the error where if there is no deepValue

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -308,7 +308,7 @@ export function deepValue(obj: any, str: string) {
     var a = str.split(".");
     for (var i = 0, n = a.length; i < n; ++i) {
         var k = a[i];
-        if (k in obj) {
+        if (obj !== null && k in obj) {
             obj = obj[k];
         } else {
             return null;


### PR DESCRIPTION
# Description

## Deep Values
```
deepValue:
    very:
        very:
            very:
                very: 
                    very:
                        deep: 27.4
```
                    
Если убрать значение **deep: 27.4**:
```


deepValue:
    very:
        very:
            very:
                very: 
                    very:
```

It will be a mistake (very is null)


```
``` tracker
searchType: frontmatter
searchTarget: deepValue.very.very.very.very.very.deep
folder: diary
endDate: 2021-01-31
line:
    title: Deep Values
```
```

With this error, nothing was displayed in the tracker

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- I changed my js code and my data started to be displayed again
