### PR TITLE
Fix issue #298: Added DatasetName as title for calendar in annotation mode

### DIFF
--- a/src/month.ts
+++ b/src/month.ts
@@ -300,41 +300,36 @@ function renderMonthHeader(
         datasetName,
         "tracker-month-title-rotator"
     );
-    if (
-        monthInfo.mode === "circle" ||
-        (monthInfo.mode === "annotation" &&
-            !monthInfo.showAnnotationOfAllTargets)
-    ) {
-        let datasetRotator = headerGroup
-            .append("text")
-            .text(datasetName)
-            .attr(
-                "transform",
-                "translate(" +
-                    3.5 * cellSize +
-                    "," +
-                    datasetNameSize.height +
-                    ")"
-            )
-            .attr("class", "tracker-month-title-rotator")
-            .style("cursor", "pointer")
-            .on("click", function (event: any) {
-                // show next target
-                if (toNextDataset(renderInfo, monthInfo)) {
-                    // clear circles
-                    clearSelection(chartElements, monthInfo);
+    
+    let datasetRotator = headerGroup
+        .append("text")
+        .text(datasetName)
+        .attr(
+            "transform",
+            "translate(" +
+                3.5 * cellSize +
+                "," +
+                datasetNameSize.height +
+                ")"
+        )
+        .attr("class", "tracker-month-title-rotator")
+        .style("cursor", "pointer")
+        .on("click", function (event: any) {
+            // show next target
+            if (toNextDataset(renderInfo, monthInfo)) {
+                // clear circles
+                clearSelection(chartElements, monthInfo);
 
-                    refresh(
-                        canvas,
-                        chartElements,
-                        renderInfo,
-                        monthInfo,
-                        curMonthDate
-                    );
-                }
-            });
-        chartElements["rotator"] = datasetRotator;
-    }
+                refresh(
+                    canvas,
+                    chartElements,
+                    renderInfo,
+                    monthInfo,
+                    curMonthDate
+                );
+            }
+        });
+    chartElements["rotator"] = datasetRotator;
 
     // value monitor
     let monitorTextSize = helper.measureTextSize(


### PR DESCRIPTION
# Description

The DatasetName of the calendar view in tracker was not being set as title for annotation mode. Changes have been made to show the DatasetName to be title of the calendar irrespective of the mode 

Fixes #298 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] If this is a bug fix, did you add or update a test file to the examples directory that verifies the bug is fixed?
I believe the relevant cases already exist and this is inherently expected behaviour
