### PR TITLE
Resolve scaling issue when navigating between monthly views (#169)

### DIFF
--- a/src/month.ts
+++ b/src/month.ts
@@ -1088,6 +1088,8 @@ function refresh(
     );
 
     renderMonthDays(canvas, chartElements, renderInfo, monthInfo, curMonthDate);
+
+    setChartScale(canvas, chartElements, renderInfo);
 }
 
 export function renderMonth(


### PR DESCRIPTION
# Description

This PR fixes an issue where the calendar view reverted to its default size when users clicked the previous or next month buttons, ignoring any custom scaling set by the user. The problem occurred because the chart’s scale was not being applied during calendar refreshes. With this fix, the calendar now retains the user-defined scale when navigating between months.

Fixes #169, #113

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] If this is a bug fix, did you add or update a test file to the examples directory that verifies the bug is fixed?
This is inherently expected behaviour and needs no test cases
