### PR TITLE
Adding thresholdType parameter to Calendars

### DIFF
--- a/docs/InputParameters.md
+++ b/docs/InputParameters.md
@@ -139,6 +139,7 @@ These key-value pairs should be placed under the key `month`.
 | `dataset` | Index of the dataset of your interest | 1~NT | all indices of non-x searchTarget |
 | `startWeekOn` | First day of a week ('Sun'\|'Mon') | 1 | 'Sun' |
 | `threshold` | Threshold to determine showing a circle on a day or not | 1~NT | 0 |
+| `thresholdType` | Pick one of the two (GreaterThan\|LessThan) | 2 | GreaterThan
 | `yMin` | Minimum value | 1~NT | Minimum value of the dataset |
 | `yMax` | Maximum value | 1~NT | Maximum value of the dataset |
 | `showCircle` | Circle the day label if the collected value reach the threshold (value > `threshold`) | 1 | true |

--- a/examples/TestCalendar.md
+++ b/examples/TestCalendar.md
@@ -81,7 +81,7 @@ endDate: 2021-01-31
 month:
     startWeekOn:
     threshold: 40
-    thresholdType: lessthan
+    thresholdType: LessThan
     color: green
     headerMonthColor: orange
     dimNotInMonth: false

--- a/examples/TestCalendar.md
+++ b/examples/TestCalendar.md
@@ -70,6 +70,26 @@ month:
     showSelectedValue: true
 ```
 
+### Colored by Threshold and thresholdType
+Use parameters threshold and thresholdType - "LessThan" to color the circles
+``` tracker
+searchType: tag
+searchTarget: exercise-pushup
+datasetName: PushUp
+folder: diary
+endDate: 2021-01-31
+month:
+    startWeekOn:
+    threshold: 40
+    thresholdType: lessthan
+    color: green
+    headerMonthColor: orange
+    dimNotInMonth: false
+    todayRingColor: orange
+    selectedRingColor: steelblue
+    showSelectedValue: true
+```
+
 ### Check minDate, minValue, maxDate, maxValue
 ``` tracker
 searchType: tag

--- a/src/data.ts
+++ b/src/data.ts
@@ -37,6 +37,11 @@ export enum ValueType {
     String,
 }
 
+export enum ThresholdType {
+    GreaterThan = "greaterthan",
+    LessThan = "lessthan"
+}
+
 export type TextValueMap = {
     [key: string]: number;
 };
@@ -860,6 +865,7 @@ export class MonthInfo implements IGraph {
     dataset: number[];
     startWeekOn: string;
     threshold: number[];
+    thresholdType: string[];
     yMin: number[];
     yMax: number[];
     color: string;
@@ -896,6 +902,7 @@ export class MonthInfo implements IGraph {
         this.dataset = [];
         this.startWeekOn = "Sun";
         this.threshold = []; // if value > threshold, will show dot
+        this.thresholdType = []; 
         this.yMin = [];
         this.yMax = [];
         this.color = null;

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -16,6 +16,7 @@ import {
     Dataset,
     CustomDatasetInfo,
     AspectRatio,
+    ThresholdType
 } from "./data";
 import { TFolder, normalizePath } from "obsidian";
 import { parseYaml } from "obsidian";
@@ -1042,7 +1043,7 @@ export function getRenderInfoFromYaml(
         searchType.filter((t) => t !== SearchType.Table).length > 0
     ) {
         let errorMessage =
-            "searchType 'table' doestn't work with other types for now";
+            "searchType 'table' doesn't work with other types for now";
         return errorMessage;
     }
     // console.log(searchType);
@@ -2087,6 +2088,33 @@ export function getRenderInfoFromYaml(
             return errorMessage;
         }
         // console.log(month.threshold);
+
+        // thresholdType
+        let retThresholdType = getStringArray("thresholdType", yamlMonth?.thresholdType);
+        if (typeof retThresholdType === "string") {
+            return retThresholdType;
+        }
+        month.thresholdType = retThresholdType;
+        if (month.thresholdType.length === 0) {
+            for (let indDataset = 0; indDataset < numDataset; indDataset++) {
+                month.thresholdType.push(ThresholdType.GreaterThan);
+            }
+        }
+        if (month.thresholdType.length !== month.dataset.length) {
+            const errorMessage =
+                "The number of inputs of thresholdType and dataset not matched";
+            return errorMessage;
+        }
+        for(let ind in month.thresholdType) {
+            if(!Object.values(ThresholdType).includes(month.thresholdType[ind].toLowerCase() as ThresholdType)) {
+                const errorMessage =
+                    "thresholdType should be either 'GreaterThan' or 'LessThan'";
+                return errorMessage;
+            } else {
+                month.thresholdType[ind] = month.thresholdType[ind].toLowerCase();
+            }
+        }
+        // console.log(month.thresholdType);
 
         // yMin
         let retYMin = getNumberArray("yMin", yamlMonth?.yMin);


### PR DESCRIPTION
# Description

Previously, we only allowed threshold's of type 'greaterThan' to maintain streaks in a calendar by default. This change adds a  new Parameter 'thresholdType' to let users choose between 'greaterThan' and 'lessThan' thresholds. The default value if the thresholdType parameter is not used still remains 'greaterThan'

Usecase Example - Now Users can set thresholds to break habits. Streak stays only if they played video games 'lessThan' 2 hours per day

Fixes # (issue)
#195, #246

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] If this is a new feature, did you add files to the examples directory to demonstrate the feature?
- [x] If this is a new feature, did you add documentation to the docs directory for the feature?
