### PR TITLE
Enable bar chart full-bar display at beginning and end

### DIFF
--- a/docs/InputParameters.md
+++ b/docs/InputParameters.md
@@ -103,6 +103,7 @@ These key-value pairs should be placed under the key `bar`.
 | Key | Description | Number of Values | Default |
 |:--------|:-------|:-----------:|:------|
 | `barColor` | Color of bars in the chart | 1~NT | #69b3a2 |
+| `xAxisPadding` | Padding to ensure bars are fully displayed | 1~2 | null |
 | `yAxisLocation` |  Corresponding y-axis for the dataset (left\|right) | 1~NT | left |
 
 ### Parameters for a Summary

--- a/examples/TestBarChart.md
+++ b/examples/TestBarChart.md
@@ -24,7 +24,7 @@ endDate: 2021-01-31
 bar:
     title: Weight Log
     yAxisLabel: Weight
-    xAxisPadding: 0.5d
+    xAxisPadding: 12h
     yAxisUnit: kg
     yMin: 0
     barColor: brown
@@ -68,6 +68,7 @@ stack: true
 bar:
     title: Sin Square Wave (Stacked)
     yAxisLabel: Value
+    xAxisPadding: 12h
     yMin: 0
     barColor: yellow, red, green, blue, orange, black
 ```

--- a/examples/TestBarChart.md
+++ b/examples/TestBarChart.md
@@ -9,6 +9,7 @@ endDate: 2021-01-05
 bar:
     title: Weight Log
     yAxisLabel: Weight
+    xAxisPadding: 12h
     yAxisUnit: kg
     yMin: 0
     barColor: darkolivegreen
@@ -23,6 +24,7 @@ endDate: 2021-01-31
 bar:
     title: Weight Log
     yAxisLabel: Weight
+    xAxisPadding: 0.5d
     yAxisUnit: kg
     yMin: 0
     barColor: brown
@@ -37,6 +39,7 @@ endDate: 2021-01-21
 bar:
     title: Sin Wave
     yAxisLabel: Value
+    xAxisPadding: 12h
     barColor: yellow, red, green
 ```
 
@@ -49,6 +52,7 @@ endDate: 2021-01-05
 bar:
     title: Sin Square Wave
     yAxisLabel: Value
+    xAxisPadding: 12h
     yMin: 0
     barColor: yellow, red, green, blue, orange, white
 ```

--- a/src/data.ts
+++ b/src/data.ts
@@ -786,11 +786,13 @@ export class LineInfo extends CommonChartInfo {
 export class BarInfo extends CommonChartInfo {
     barColor: string[];
     yAxisLocation: string[];
+    xAxisPadding: string;
 
     constructor() {
         super();
         this.barColor = []; // #69b3a2
         this.yAxisLocation = []; // left, for each target
+        this.xAxisPadding = null; // the string will be converted to Duration (a month is not nesscesary to 30 days)
     }
 
     public GetGraphType() {

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -1835,6 +1835,14 @@ export function getRenderInfoFromYaml(
         bar.yAxisLocation = retYAxisLocation;
         // console.log(bar.yAxisLocation);
 
+        // xAxisPadding
+        let retXAxisPadding = getStringFromInput(
+            yamlBar?.xAxisPadding,
+            null
+        );
+        bar.xAxisPadding = retXAxisPadding;
+        // console.log(bar.xAxisPadding);
+
         renderInfo.bar.push(bar);
     } // bar related parameters
     // console.log(renderInfo.bar);

--- a/src/rendering.ts
+++ b/src/rendering.ts
@@ -307,16 +307,18 @@ function renderXAxis(
 
     let datasets = renderInfo.datasets;
     let xDomain = d3.extent(datasets.getDates());
-    if (chartInfo instanceof BarInfo && chartInfo.xAxisPadding) {
+    if (chartInfo instanceof BarInfo && chartInfo.xAxisPadding !== null) {
         let xAxisPaddingDuration = helper.parseDurationString(
             chartInfo.xAxisPadding
         );
-        xDomain = [
-            xDomain[0].clone().subtract(xAxisPaddingDuration.asHours(), 'hours'),
-            xDomain[1].clone().add(xAxisPaddingDuration.asHours(), 'hours'),
-        ];
+        if (xAxisPaddingDuration !== null) {
+            xDomain = [
+                xDomain[0].clone().subtract(xAxisPaddingDuration.asHours(), 'hours'),
+                xDomain[1].clone().add(xAxisPaddingDuration.asHours(), 'hours'),
+            ];
+        }
     }
-    console.log(xDomain);
+    // console.log(xDomain);
     let xScale = d3
         .scaleTime()
         .domain(xDomain)
@@ -964,13 +966,8 @@ function renderBar(
         .enter()
         .append("rect")
         .attr("x", function (p: DataPoint, i: number) {
-<<<<<<< Updated upstream
-            if (i === 0) {
-                let portionVisible = currentDiaplayInd + 1 - totalDiaplaySet / 2.0;
-=======
             if (i === 0 && barInfo.xAxisPadding === null) {
-                let portionVisible = currBarSet + 1 - totalNumOfBarSets / 2.0;
->>>>>>> Stashed changes
+                let portionVisible = currentDiaplayInd + 1 - totalDiaplaySet / 2.0;
                 if (portionVisible < 1.0) {
                     return (
                         chartElements.xScale(p.date) -
@@ -990,13 +987,8 @@ function renderBar(
             return yScale(Math.max(p.value, 0));
         })
         .attr("width", function (p: DataPoint, i: number) {
-<<<<<<< Updated upstream
-            if (i === 0) {
-                let portionVisible = currentDiaplayInd + 1 - totalDiaplaySet / 2.0;
-=======
             if (i === 0 && barInfo.xAxisPadding === null) {
-                let portionVisible = currBarSet + 1 - totalNumOfBarSets / 2.0;
->>>>>>> Stashed changes
+                let portionVisible = currentDiaplayInd + 1 - totalDiaplaySet / 2.0;
                 if (portionVisible < 0.0) {
                     return 0.0;
                 } else if (portionVisible < 1.0) {

--- a/src/rendering.ts
+++ b/src/rendering.ts
@@ -307,6 +307,16 @@ function renderXAxis(
 
     let datasets = renderInfo.datasets;
     let xDomain = d3.extent(datasets.getDates());
+    if (chartInfo instanceof BarInfo && chartInfo.xAxisPadding) {
+        let xAxisPaddingDuration = helper.parseDurationString(
+            chartInfo.xAxisPadding
+        );
+        xDomain = [
+            xDomain[0].clone().subtract(xAxisPaddingDuration.asHours(), 'hours'),
+            xDomain[1].clone().add(xAxisPaddingDuration.asHours(), 'hours'),
+        ];
+    }
+    console.log(xDomain);
     let xScale = d3
         .scaleTime()
         .domain(xDomain)
@@ -954,8 +964,13 @@ function renderBar(
         .enter()
         .append("rect")
         .attr("x", function (p: DataPoint, i: number) {
+<<<<<<< Updated upstream
             if (i === 0) {
                 let portionVisible = currentDiaplayInd + 1 - totalDiaplaySet / 2.0;
+=======
+            if (i === 0 && barInfo.xAxisPadding === null) {
+                let portionVisible = currBarSet + 1 - totalNumOfBarSets / 2.0;
+>>>>>>> Stashed changes
                 if (portionVisible < 1.0) {
                     return (
                         chartElements.xScale(p.date) -
@@ -975,15 +990,20 @@ function renderBar(
             return yScale(Math.max(p.value, 0));
         })
         .attr("width", function (p: DataPoint, i: number) {
+<<<<<<< Updated upstream
             if (i === 0) {
                 let portionVisible = currentDiaplayInd + 1 - totalDiaplaySet / 2.0;
+=======
+            if (i === 0 && barInfo.xAxisPadding === null) {
+                let portionVisible = currBarSet + 1 - totalNumOfBarSets / 2.0;
+>>>>>>> Stashed changes
                 if (portionVisible < 0.0) {
                     return 0.0;
                 } else if (portionVisible < 1.0) {
                     return barWidth * portionVisible;
                 }
                 return barWidth;
-            } else if (i === dataset.getLength() - 1) {
+            } else if (i === dataset.getLength() - 1 && barInfo.xAxisPadding === null) {
                 let portionVisible =
                     1.0 - (currentDiaplayInd + 1 - totalDiaplaySet / 2.0);
                 if (portionVisible < 0.0) {


### PR DESCRIPTION
# Description

Currently only half of the starting/ending ds is shown when displaying barcharts.

![Screenshot 2025-05-10 175413](https://github.com/user-attachments/assets/21372eac-b152-4b27-ae1c-e5317d013357)


This change will allow user to set `xAxisPadding`, and when set to 12h, will exactly show the full bar.
![Screenshot 2025-05-10 175449](https://github.com/user-attachments/assets/fe35b312-775d-4e4e-b7b3-413f22de6f7b)


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] If this is a new feature, did you add files to the examples directory to demonstrate the feature?
- [x] If this is a new feature, did you add documentation to the docs directory for the feature?
